### PR TITLE
stylesheet.css: make sure body color is #000

### DIFF
--- a/content/theme/stylesheet.css
+++ b/content/theme/stylesheet.css
@@ -4,6 +4,7 @@
 }
 
 body {
+  color: #000000;
   background-color: #fdfcfb;
   font-family: sans;
 }


### PR DESCRIPTION
This fixes the text color when viewed into browsers where the default
colors aren't the usual black on white, as can be experienced into
WebKitGTK 2.26.0+ with GTK Theming in dark mode or firefox with changing
the preferences.